### PR TITLE
Add MetaPrompt Assistant Chrome extension with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# MetaPrompt Assistant
+
+Chrome extension that provides a meta-prompting assistant in a side panel on ChatGPT pages.
+
+## Development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Run tests:
+   ```bash
+   npm test
+   ```
+
+## Loading the Extension in Chrome
+
+1. Open `chrome://extensions` and enable Developer Mode.
+2. Click "Load unpacked" and select this project folder.
+3. Navigate to https://chat.openai.com/ and open the side panel to use the assistant.

--- a/content_script.js
+++ b/content_script.js
@@ -1,0 +1,36 @@
+function collectConversation() {
+  const nodes = document.querySelectorAll('[data-message-id]');
+  return Array.from(nodes).map((el) => ({
+    role: el.getAttribute('data-message-author') || '',
+    content: el.textContent.trim()
+  }));
+}
+
+function injectPrompt(prompt) {
+  const textarea = document.querySelector('textarea');
+  if (!textarea) return;
+  textarea.value = prompt;
+  textarea.dispatchEvent(new Event('input', { bubbles: true }));
+  const sendBtn = textarea.closest('form')?.querySelector("button[type='submit']");
+  sendBtn && sendBtn.click();
+}
+
+function handleMessage(message, sender, sendResponse) {
+  if (message.type === 'get-conversation') {
+    sendResponse({ conversation: collectConversation() });
+  }
+  if (message.type === 'inject-prompt') {
+    injectPrompt(message.prompt);
+  }
+}
+
+chrome.runtime.onMessage.addListener(handleMessage);
+
+const observer = new MutationObserver(() => {
+  chrome.runtime.sendMessage({ type: 'conversation-update', conversation: collectConversation() });
+});
+observer.observe(document.body, { childList: true, subtree: true });
+
+if (typeof module !== 'undefined') {
+  module.exports = { collectConversation, injectPrompt, handleMessage };
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "MetaPrompt Assistant",
+  "version": "1.0",
+  "description": "Meta-prompting assistant for ChatGPT.",
+  "permissions": ["sidePanel", "scripting", "activeTab", "storage"],
+  "host_permissions": ["https://chat.openai.com/*"],
+  "background": {
+    "service_worker": "service-worker.js"
+  },
+  "side_panel": {
+    "default_path": "sidepanel.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://chat.openai.com/*"],
+      "js": ["content_script.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "metaprompt-assistant",
+  "version": "1.0.0",
+  "description": "Chrome extension for meta-prompting assistant",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,28 @@
+let chatGPTTabId = null;
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (tab.url && tab.url.startsWith('https://chat.openai.com/')) {
+    chatGPTTabId = tabId;
+    chrome.sidePanel.setOptions({ tabId, path: 'sidepanel.html' });
+    chrome.sidePanel.show(tabId);
+  }
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  if (tabId === chatGPTTabId) {
+    chatGPTTabId = null;
+  }
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!chatGPTTabId) {
+    return;
+  }
+  if (message.type === 'request-conversation') {
+    chrome.tabs.sendMessage(chatGPTTabId, { type: 'get-conversation' }, sendResponse);
+    return true; // keep sendResponse
+  }
+  if (message.type === 'send-prompt') {
+    chrome.tabs.sendMessage(chatGPTTabId, { type: 'inject-prompt', prompt: message.prompt });
+  }
+});

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="conversation"></div>
+  <div id="clarification">
+    <input type="text" id="objective" placeholder="State your objective" />
+    <button id="clarify-btn">Clarify</button>
+  </div>
+  <div id="prompt-section" style="display:none;">
+    <textarea id="final-prompt"></textarea>
+    <button id="send-btn">Send to AI</button>
+    <div id="suggestion"></div>
+  </div>
+  <script src="utils.js"></script>
+  <script src="sidepanel.js"></script>
+</body>
+</html>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1,0 +1,40 @@
+const conversationDiv = document.getElementById('conversation');
+const objectiveInput = document.getElementById('objective');
+const clarifyBtn = document.getElementById('clarify-btn');
+const promptSection = document.getElementById('prompt-section');
+const finalPrompt = document.getElementById('final-prompt');
+const sendBtn = document.getElementById('send-btn');
+const suggestionDiv = document.getElementById('suggestion');
+
+chrome.runtime.sendMessage({ type: 'request-conversation' }, (res) => {
+  if (res && res.conversation) {
+    conversationDiv.textContent = res.conversation.map(m => `${m.role}: ${m.content}`).join('\n');
+  }
+});
+
+clarifyBtn.addEventListener('click', () => {
+  const objective = objectiveInput.value.trim();
+  if (!objective) return;
+  const context = conversationDiv.textContent;
+  const prompt = generateOptimizedPrompt(objective, context);
+  finalPrompt.value = prompt;
+  promptSection.style.display = 'block';
+});
+
+sendBtn.addEventListener('click', () => {
+  const prompt = finalPrompt.value;
+  chrome.runtime.sendMessage({ type: 'send-prompt', prompt });
+});
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === 'conversation-update' && msg.conversation) {
+    const last = msg.conversation[msg.conversation.length - 1];
+    const objective = objectiveInput.value.trim();
+    const result = detectMisalignment(objective, last.content);
+    if (result.misaligned) {
+      suggestionDiv.textContent = result.suggestion;
+    } else {
+      suggestionDiv.textContent = '';
+    }
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,21 @@
+body {
+  font-family: sans-serif;
+  padding: 10px;
+  width: 300px;
+}
+#conversation {
+  white-space: pre-wrap;
+  border: 1px solid #ccc;
+  padding: 5px;
+  height: 150px;
+  overflow-y: auto;
+  margin-bottom: 10px;
+}
+textarea {
+  width: 100%;
+  height: 100px;
+}
+#suggestion {
+  color: #b00;
+  margin-top: 10px;
+}

--- a/tests/content_script.test.js
+++ b/tests/content_script.test.js
@@ -1,0 +1,37 @@
+describe('content_script functions', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    global.chrome = { runtime: { sendMessage: jest.fn(), onMessage: { addListener: jest.fn() } } };
+    document.body.innerHTML = `
+      <div data-message-id="1" data-message-author="user">Hi</div>
+      <div data-message-id="2" data-message-author="assistant">Hello</div>
+      <form><textarea></textarea><button type="submit"></button></form>
+    `;
+  });
+
+  test('collectConversation gathers messages', () => {
+    const { collectConversation } = require('../content_script');
+    const conv = collectConversation();
+    expect(conv.length).toBe(2);
+    expect(conv[0].role).toBe('user');
+  });
+
+  test('injectPrompt sets textarea and clicks send', () => {
+    const { injectPrompt } = require('../content_script');
+    const btn = document.querySelector('button');
+    const clickSpy = jest.spyOn(btn, 'click');
+    injectPrompt('hello world');
+    expect(document.querySelector('textarea').value).toBe('hello world');
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  test('handleMessage routes messages', () => {
+    const mod = require('../content_script');
+    const sendResponse = jest.fn();
+    mod.handleMessage({ type: 'get-conversation' }, {}, sendResponse);
+    expect(sendResponse).toHaveBeenCalled();
+    const spy = jest.spyOn(mod, 'injectPrompt');
+    mod.handleMessage({ type: 'inject-prompt', prompt: 'x' });
+    expect(spy).toHaveBeenCalledWith('x');
+  });
+});

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,28 @@
+const { JSDOM } = require('jsdom');
+const { parseConversation, generateOptimizedPrompt, detectMisalignment } = require('../utils');
+
+test('parseConversation extracts role and content', () => {
+  const dom = new JSDOM(`\n    <div class="message" data-role="user">Hello</div>\n    <div class="message" data-role="assistant">Hi there</div>\n  `);
+  const msgs = parseConversation(dom.window.document);
+  expect(msgs).toEqual([
+    { role: 'user', content: 'Hello' },
+    { role: 'assistant', content: 'Hi there' }
+  ]);
+});
+
+test('generateOptimizedPrompt includes objective and context', () => {
+  const prompt = generateOptimizedPrompt('summarize', 'context text');
+  expect(prompt).toMatch(/summarize/);
+  expect(prompt).toMatch(/context text/);
+});
+
+test('detectMisalignment flags missing objective keyword', () => {
+  const res = detectMisalignment('summarize', 'This is unrelated');
+  expect(res.misaligned).toBe(true);
+  expect(res.suggestion).toMatch(/summarize/);
+});
+
+test('detectMisalignment passes when keyword present', () => {
+  const res = detectMisalignment('summarize', 'Please summarize this');
+  expect(res.misaligned).toBe(false);
+});

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,21 @@
+function parseConversation(doc) {
+  const nodes = doc.querySelectorAll('.message');
+  return Array.from(nodes).map((el) => ({
+    role: el.getAttribute('data-role') || '',
+    content: el.textContent.trim()
+  }));
+}
+
+function generateOptimizedPrompt(objective, context = '') {
+  return `You are to ${objective.trim()}\nContext: ${context.trim()}`.trim();
+}
+
+function detectMisalignment(objective, aiResponse) {
+  const key = objective.split(' ')[0].toLowerCase();
+  const aligned = aiResponse.toLowerCase().includes(key);
+  return aligned ? { misaligned: false } : { misaligned: true, suggestion: `Response may not address ${key}` };
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { parseConversation, generateOptimizedPrompt, detectMisalignment };
+}


### PR DESCRIPTION
## Summary
- implement MetaPrompt Assistant side-panel extension for ChatGPT
- add utilities for prompt generation and misalignment detection
- create Jest tests for main logic and provide usage instructions

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bb1e515ec8323b7687672dfa8d483