### PR TITLE
Support chatgpt.com domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ npm test
 
 1. Open `chrome://extensions` and enable Developer Mode.
 2. Click "Load unpacked" and select this project folder.
-3. Navigate to https://chat.openai.com/ and open the side panel to use the assistant.
+3. Navigate to https://chat.openai.com/ or https://chatgpt.com/ and open the side panel to use the assistant.

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,10 @@
   "version": "1.0",
   "description": "Meta-prompting assistant for ChatGPT.",
   "permissions": ["sidePanel", "scripting", "activeTab", "storage"],
-  "host_permissions": ["https://chat.openai.com/*"],
+  "host_permissions": [
+    "https://chat.openai.com/*",
+    "https://chatgpt.com/*"
+  ],
   "background": {
     "service_worker": "service-worker.js"
   },
@@ -13,7 +16,10 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://chat.openai.com/*"],
+      "matches": [
+        "https://chat.openai.com/*",
+        "https://chatgpt.com/*"
+      ],
       "js": ["content_script.js"],
       "run_at": "document_idle"
     }

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,11 @@
 let chatGPTTabId = null;
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (tab.url && tab.url.startsWith('https://chat.openai.com/')) {
+  if (
+    tab.url &&
+    (tab.url.startsWith('https://chat.openai.com/') ||
+      tab.url.startsWith('https://chatgpt.com/'))
+  ) {
     chatGPTTabId = tabId;
     chrome.sidePanel.setOptions({ tabId, path: 'sidepanel.html' });
     chrome.sidePanel.show(tabId);


### PR DESCRIPTION
## Summary
- allow extension to run on chatgpt.com by updating manifest host and match permissions
- broaden service worker URL detection to handle chatgpt.com as well as chat.openai.com
- document new domain support in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bc37826a4832390a3f6dcfc672f6e